### PR TITLE
Adding -no-raw option to stay in cooked mode; added -fps option to debug exercise the more complex part of fortio.org/terminal/ansipixels stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ go.work
 go.work.sum
 .goreleaser.yaml
 tev
+.gr

--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ brew install fortio/tap/tev
 ```
 tev help
 ```
+
+By defaults it will put the terminal in raw mode, turn on mouse tracking and show exactly what the terminal emulator is sending and in how many batches (of up to 1024 which is the internal ansipixels buffer size). Various flag allow to change what the terminal does (raw, mouse, bracketed paste, etc..)

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ brew install fortio/tap/tev
 tev help
 ```
 
-By defaults it will put the terminal in raw mode, turn on mouse tracking and show exactly what the terminal emulator is sending and in how many batches (of up to 1024 which is the internal ansipixels buffer size). Various flag allow to change what the terminal does (raw, mouse, bracketed paste, etc..)
+By default it will put the terminal in raw mode, turn on mouse tracking and show exactly what the terminal emulator is sending and in how many batches (of up to 1024 which is the internal ansipixels buffer size). Various flag allow to change what the terminal does (raw, mouse, bracketed paste, etc..)


### PR DESCRIPTION
-fps is only... for me/to double check ansipixels behaviour - including combined with 
```sh
go run -tags test_alt_timeoutreader .
```
tag for the 2 different ways to get timeout reads (select vs extra go routine)
