### PR TITLE
Skip tabs detection when sending code

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ $ tev -no-mouse
 20:41:10.428 [INF] Read 1 bytes: "\x03"
 20:41:10.428 [INF] 3rd Ctrl-C received, exiting now.```
 ```
+
+You can also see the effect of some codes:
+```sh
+$ tev -code '\033]11;?\007'
+17:15:06.997 [INF] Sending code flag "\x1b]11;?\a"
+17:15:06.998 [INF] Read 24 bytes: "\x1b]11;rgb:1e1e/1e1e/1e1e\a"
+```

--- a/tev.go
+++ b/tev.go
@@ -104,7 +104,8 @@ func Main() int {
 	} else {
 		log.Infof("Bracketed paste mode disabled")
 	}
-	if *codeFlag != "" {
+	switch {
+	case *codeFlag != "":
 		inp := "\"" + *codeFlag + "\""
 		dec, err := strconv.Unquote(inp)
 		if err != nil {
@@ -112,14 +113,13 @@ func Main() int {
 		}
 		log.Infof("Sending code flag %q", dec)
 		ap.WriteString(dec)
+	case !*noRawFlag:
+		log.Infof("Tabs: %v", GetTabStops(ap))
+	default:
+		log.Infof("Sample tabs:\n\t0\t1\t2\t3\t4\t5\t6\t7\t8")
 	}
 	ap.Out.Flush()
 	log.Infof("Fortio terminal event dump started. ^C 3 times to exit (or pkill tev). Ctrl-L clears the screen.")
-	if !*noRawFlag {
-		log.Infof("Tabs: %v", GetTabStops(ap))
-	} else {
-		log.Infof("Sample tabs:\n\t0\t1\t2\t3\t4\t5\t6\t7\t8")
-	}
 	return DebugLoop(ap, echoMode)
 }
 


### PR DESCRIPTION
so we can see for instance the rgb background with
```sh
tev -code '\033]11;?\007'
```